### PR TITLE
Removes freePort from the HAL

### DIFF
--- a/hal/include/HAL/HAL.h
+++ b/hal/include/HAL/HAL.h
@@ -110,7 +110,6 @@ extern const uint32_t kSystemClockTicksPerMicrosecond;
 
 HalPortHandle getPort(uint8_t pin);
 HalPortHandle getPortWithModule(uint8_t module, uint8_t pin);
-void freePort(HalPortHandle port);
 const char* getHALErrorMessage(int32_t code);
 
 uint16_t getFPGAVersion(int32_t* status);

--- a/hal/lib/athena/HALAthena.cpp
+++ b/hal/lib/athena/HALAthena.cpp
@@ -54,10 +54,6 @@ HalPortHandle getPortWithModule(uint8_t module, uint8_t pin) {
   return createPortHandle(pin, module);
 }
 
-void freePort(HalPortHandle port_handle) {
-  // noop
-}
-
 const char* getHALErrorMessage(int32_t code) {
   switch (code) {
     case 0:

--- a/wpilibc/athena/src/AnalogInput.cpp
+++ b/wpilibc/athena/src/AnalogInput.cpp
@@ -48,7 +48,6 @@ AnalogInput::AnalogInput(uint32_t channel) {
   int32_t status = 0;
   m_port = initializeAnalogInputPort(port, &status);
   wpi_setErrorWithContext(status, getHALErrorMessage(status));
-  freePort(port);
 
   LiveWindow::GetInstance()->AddSensor("AnalogInput", channel, this);
   HALReport(HALUsageReporting::kResourceType_AnalogChannel, channel);

--- a/wpilibc/athena/src/AnalogOutput.cpp
+++ b/wpilibc/athena/src/AnalogOutput.cpp
@@ -36,7 +36,6 @@ AnalogOutput::AnalogOutput(uint32_t channel) {
   HalPortHandle port = getPort(m_channel);
   int32_t status = 0;
   m_port = initializeAnalogOutputPort(port, &status);
-  freePort(port);
   if (status != 0) {
     wpi_setErrorWithContext(status, getHALErrorMessage(status));
     m_channel = std::numeric_limits<uint32_t>::max();

--- a/wpilibc/athena/src/AnalogTrigger.cpp
+++ b/wpilibc/athena/src/AnalogTrigger.cpp
@@ -26,7 +26,6 @@ AnalogTrigger::AnalogTrigger(int32_t channel) {
   uint32_t index = 0;
   m_trigger = initializeAnalogTrigger(port, &index, &status);
   wpi_setErrorWithContext(status, getHALErrorMessage(status));
-  freePort(port);
   m_index = index;
 
   HALReport(HALUsageReporting::kResourceType_AnalogTrigger, channel);

--- a/wpilibc/athena/src/SensorBase.cpp
+++ b/wpilibc/athena/src/SensorBase.cpp
@@ -35,7 +35,6 @@ SensorBase::SensorBase() {
       int32_t status = 0;
       m_digital_ports[i] = initializeDigitalPort(port, &status);
       wpi_setErrorWithContext(status, getHALErrorMessage(status));
-      freePort(port);
     }
 
     for (uint32_t i = 0; i < kRelayChannels; i++) {
@@ -43,7 +42,6 @@ SensorBase::SensorBase() {
       int32_t status = 0;
       m_relay_ports[i] = initializeDigitalPort(port, &status);
       wpi_setErrorWithContext(status, getHALErrorMessage(status));
-      freePort(port);
     }
 
     for (uint32_t i = 0; i < kPwmChannels; i++) {
@@ -51,7 +49,6 @@ SensorBase::SensorBase() {
       int32_t status = 0;
       m_pwm_ports[i] = initializeDigitalPort(port, &status);
       wpi_setErrorWithContext(status, getHALErrorMessage(status));
-      freePort(port);
     }
   }
 }

--- a/wpilibc/athena/src/SolenoidBase.cpp
+++ b/wpilibc/athena/src/SolenoidBase.cpp
@@ -25,7 +25,6 @@ SolenoidBase::SolenoidBase(uint8_t moduleNumber)
     SolenoidBase::m_ports[moduleNumber][i] =
         initializeSolenoidPort(port, &status);
     wpi_setErrorWithContext(status, getHALErrorMessage(status));
-    freePort(port);
   }
 }
 

--- a/wpilibj/src/athena/cpp/lib/JNIWrapper.cpp
+++ b/wpilibj/src/athena/cpp/lib/JNIWrapper.cpp
@@ -45,19 +45,4 @@ JNIEXPORT jint JNICALL Java_edu_wpi_first_wpilibj_hal_JNIWrapper_getPort(
   // FILE_LOG(logDEBUG) << "Port Handle = " << port;
   return (jint)port;
 }
-
-/*
- * Class:     edu_wpi_first_wpilibj_hal_JNIWrapper
- * Method:    freePort
- * Signature: (I)V
- */
-JNIEXPORT void JNICALL Java_edu_wpi_first_wpilibj_hal_JNIWrapper_freePort(
-    JNIEnv* env, jclass, jint id) {
-  // FILE_LOG(logDEBUG) << "Calling JNIWrapper getPortWithModlue";
-  // FILE_LOG(logDEBUG) << "Module = " << (jint)module;
-  // FILE_LOG(logDEBUG) << "Pin = " << (jint)pin;
-  freePort((HalPortHandle)id);
-  // FILE_LOG(logDEBUG) << "Port Handle = " << port;
-}
-
 }  // extern "C"

--- a/wpilibj/src/athena/java/edu/wpi/first/wpilibj/AnalogOutput.java
+++ b/wpilibj/src/athena/java/edu/wpi/first/wpilibj/AnalogOutput.java
@@ -37,7 +37,6 @@ public class AnalogOutput extends SensorBase implements LiveWindowSendable {
 
     final int portHandle = AnalogJNI.getPort((byte) channel);
     m_port = AnalogJNI.initializeAnalogOutputPort(portHandle);
-    AnalogJNI.freePort(portHandle);
 
     LiveWindow.addSensor("AnalogOutput", channel, this);
     UsageReporting.report(tResourceType.kResourceType_AnalogOutput, channel);

--- a/wpilibj/src/athena/java/edu/wpi/first/wpilibj/hal/JNIWrapper.java
+++ b/wpilibj/src/athena/java/edu/wpi/first/wpilibj/hal/JNIWrapper.java
@@ -62,6 +62,4 @@ public class JNIWrapper {
   public static native int getPortWithModule(byte module, byte pin);
 
   public static native int getPort(byte pin);
-
-  public static native void freePort(int halPortHandle);
 }


### PR DESCRIPTION
It was a no-op, and most likely in the future it will be that way too.
Removing to clean up the API.
