### PR TITLE
Fixes halsim_print to not try and build when the 'onlyAthena' flag has been set

### DIFF
--- a/simulation/halsim_print/build.gradle
+++ b/simulation/halsim_print/build.gradle
@@ -3,6 +3,9 @@ description = "A simulation shared object that simply prints robot behaviors"
 apply plugin: 'edu.wpi.first.NativeUtils'
 apply plugin: 'cpp'
 
+if (!project.hasProperty('onlyAthena'))
+{
+
 ext.skipAthena = true
 
 apply from: "../../config.gradle"
@@ -24,3 +27,5 @@ model {
     }
 }
 apply from: 'publish.gradle'
+
+}


### PR DESCRIPTION
Building a non-athena library in athena only is not possible.