### PR TITLE
Adds all HALSim symbols to Athena HAL

### DIFF
--- a/hal/src/main/native/athena/MockDataShim/AccelerometerData.cpp
+++ b/hal/src/main/native/athena/MockDataShim/AccelerometerData.cpp
@@ -1,0 +1,70 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2017 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "MockData/AccelerometerData.h"
+
+extern "C" {
+
+void HALSIM_ResetAccelerometerData(int32_t index) {}
+int32_t HALSIM_RegisterAccelerometerActiveCallback(int32_t index,
+                                                   HAL_NotifyCallback callback,
+                                                   void* param,
+                                                   HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelAccelerometerActiveCallback(int32_t index, int32_t uid) {}
+HAL_Bool HALSIM_GetAccelerometerActive(int32_t index) { return false; }
+void HALSIM_SetAccelerometerActive(int32_t index, HAL_Bool active) {}
+int32_t HALSIM_RegisterAccelerometerRangeCallback(int32_t index,
+                                                  HAL_NotifyCallback callback,
+                                                  void* param,
+                                                  HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelAccelerometerRangeCallback(int32_t index, int32_t uid) {}
+HAL_AccelerometerRange HALSIM_GetAccelerometerRange(int32_t index) {
+  return HAL_AccelerometerRange::HAL_AccelerometerRange_k2G;
+}
+void HALSIM_SetAccelerometerRange(int32_t index, HAL_AccelerometerRange range) {
+}
+
+int32_t HALSIM_RegisterAccelerometerXCallback(int32_t index,
+                                              HAL_NotifyCallback callback,
+                                              void* param,
+                                              HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelAccelerometerXCallback(int32_t index, int32_t uid) {}
+double HALSIM_GetAccelerometerX(int32_t index) { return 0; }
+void HALSIM_SetAccelerometerX(int32_t index, double x) {}
+
+int32_t HALSIM_RegisterAccelerometerYCallback(int32_t index,
+                                              HAL_NotifyCallback callback,
+                                              void* param,
+                                              HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelAccelerometerYCallback(int32_t index, int32_t uid) {}
+double HALSIM_GetAccelerometerY(int32_t index) { return 0; }
+void HALSIM_SetAccelerometerY(int32_t index, double y) {}
+
+int32_t HALSIM_RegisterAccelerometerZCallback(int32_t index,
+                                              HAL_NotifyCallback callback,
+                                              void* param,
+                                              HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelAccelerometerZCallback(int32_t index, int32_t uid) {}
+double HALSIM_GetAccelerometerZ(int32_t index) { return 0; }
+void HALSIM_SetAccelerometerZ(int32_t index, double z) {}
+
+void HALSIM_RegisterAccelerometerAllCallbacks(int32_t index,
+                                              HAL_NotifyCallback callback,
+                                              void* param,
+                                              HAL_Bool initialNotify) {}
+
+}  // extern "C"

--- a/hal/src/main/native/athena/MockDataShim/AnalogGyroData.cpp
+++ b/hal/src/main/native/athena/MockDataShim/AnalogGyroData.cpp
@@ -1,0 +1,47 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2017 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "MockData/AnalogGyroData.h"
+
+extern "C" {
+
+void HALSIM_ResetAnalogGyroData(int32_t index) {}
+int32_t HALSIM_RegisterAnalogGyroAngleCallback(int32_t index,
+                                               HAL_NotifyCallback callback,
+                                               void* param,
+                                               HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelAnalogGyroAngleCallback(int32_t index, int32_t uid) {}
+double HALSIM_GetAnalogGyroAngle(int32_t index) { return 0; }
+void HALSIM_SetAnalogGyroAngle(int32_t index, double angle) {}
+
+int32_t HALSIM_RegisterAnalogGyroRateCallback(int32_t index,
+                                              HAL_NotifyCallback callback,
+                                              void* param,
+                                              HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelAnalogGyroRateCallback(int32_t index, int32_t uid) {}
+double HALSIM_GetAnalogGyroRate(int32_t index) { return 0; }
+void HALSIM_SetAnalogGyroRate(int32_t index, double rate);
+
+int32_t HALSIM_RegisterAnalogGyroInitializedCallback(
+    int32_t index, HAL_NotifyCallback callback, void* param,
+    HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelAnalogGyroInitializedCallback(int32_t index, int32_t uid) {}
+HAL_Bool HALSIM_GetAnalogGyroInitialized(int32_t index) { return false; }
+void HALSIM_SetAnalogGyroInitialized(int32_t index, HAL_Bool initialized) {}
+
+void HALSIM_RegisterAnalogGyroAllCallbacks(int32_t index,
+                                           HAL_NotifyCallback callback,
+                                           void* param,
+                                           HAL_Bool initialNotify) {}
+
+}  // extern "C"

--- a/hal/src/main/native/athena/MockDataShim/AnalogInData.cpp
+++ b/hal/src/main/native/athena/MockDataShim/AnalogInData.cpp
@@ -1,0 +1,114 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2017 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "MockData/AnalogInData.h"
+
+extern "C" {
+
+void HALSIM_ResetAnalogInData(int32_t index) {}
+int32_t HALSIM_RegisterAnalogInInitializedCallback(int32_t index,
+                                                   HAL_NotifyCallback callback,
+                                                   void* param,
+                                                   HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelAnalogInInitializedCallback(int32_t index, int32_t uid) {}
+HAL_Bool HALSIM_GetAnalogInInitialized(int32_t index) { return false; }
+void HALSIM_SetAnalogInInitialized(int32_t index, HAL_Bool initialized) {}
+
+int32_t HALSIM_RegisterAnalogInAverageBitsCallback(int32_t index,
+                                                   HAL_NotifyCallback callback,
+                                                   void* param,
+                                                   HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelAnalogInAverageBitsCallback(int32_t index, int32_t uid) {}
+int32_t HALSIM_GetAnalogInAverageBits(int32_t index) { return 0; }
+void HALSIM_SetAnalogInAverageBits(int32_t index, int32_t averageBits) {}
+
+int32_t HALSIM_RegisterAnalogInOversampleBitsCallback(
+    int32_t index, HAL_NotifyCallback callback, void* param,
+    HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelAnalogInOversampleBitsCallback(int32_t index, int32_t uid) {}
+int32_t HALSIM_GetAnalogInOversampleBits(int32_t index) { return 0; }
+void HALSIM_SetAnalogInOversampleBits(int32_t index, int32_t oversampleBits) {}
+
+int32_t HALSIM_RegisterAnalogInVoltageCallback(int32_t index,
+                                               HAL_NotifyCallback callback,
+                                               void* param,
+                                               HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelAnalogInVoltageCallback(int32_t index, int32_t uid) {}
+double HALSIM_GetAnalogInVoltage(int32_t index) { return 0; }
+void HALSIM_SetAnalogInVoltage(int32_t index, double voltage) {}
+
+int32_t HALSIM_RegisterAnalogInAccumulatorInitializedCallback(
+    int32_t index, HAL_NotifyCallback callback, void* param,
+    HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelAnalogInAccumulatorInitializedCallback(int32_t index,
+                                                         int32_t uid) {}
+HAL_Bool HALSIM_GetAnalogInAccumulatorInitialized(int32_t index) {
+  return false;
+}
+void HALSIM_SetAnalogInAccumulatorInitialized(int32_t index,
+                                              HAL_Bool accumulatorInitialized) {
+}
+
+int32_t HALSIM_RegisterAnalogInAccumulatorValueCallback(
+    int32_t index, HAL_NotifyCallback callback, void* param,
+    HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelAnalogInAccumulatorValueCallback(int32_t index, int32_t uid) {
+}
+int64_t HALSIM_GetAnalogInAccumulatorValue(int32_t index) { return 0; }
+void HALSIM_SetAnalogInAccumulatorValue(int32_t index,
+                                        int64_t accumulatorValue) {}
+
+int32_t HALSIM_RegisterAnalogInAccumulatorCountCallback(
+    int32_t index, HAL_NotifyCallback callback, void* param,
+    HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelAnalogInAccumulatorCountCallback(int32_t index, int32_t uid) {
+}
+int64_t HALSIM_GetAnalogInAccumulatorCount(int32_t index) { return 0; }
+void HALSIM_SetAnalogInAccumulatorCount(int32_t index,
+                                        int64_t accumulatorCount) {}
+
+int32_t HALSIM_RegisterAnalogInAccumulatorCenterCallback(
+    int32_t index, HAL_NotifyCallback callback, void* param,
+    HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelAnalogInAccumulatorCenterCallback(int32_t index,
+                                                    int32_t uid) {}
+int32_t HALSIM_GetAnalogInAccumulatorCenter(int32_t index) { return 0; }
+void HALSIM_SetAnalogInAccumulatorCenter(int32_t index,
+                                         int32_t accumulatorCenter) {}
+
+int32_t HALSIM_RegisterAnalogInAccumulatorDeadbandCallback(
+    int32_t index, HAL_NotifyCallback callback, void* param,
+    HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelAnalogInAccumulatorDeadbandCallback(int32_t index,
+                                                      int32_t uid) {}
+int32_t HALSIM_GetAnalogInAccumulatorDeadband(int32_t index) { return 0; }
+void HALSIM_SetAnalogInAccumulatorDeadband(int32_t index,
+                                           int32_t accumulatorDeadband) {}
+
+void HALSIM_RegisterAnalogInAllCallbacks(int32_t index,
+                                         HAL_NotifyCallback callback,
+                                         void* param, HAL_Bool initialNotify) {}
+
+}  // extern "C"

--- a/hal/src/main/native/athena/MockDataShim/AnalogOutData.cpp
+++ b/hal/src/main/native/athena/MockDataShim/AnalogOutData.cpp
@@ -1,0 +1,38 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2017 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "MockData/AnalogOutData.h"
+
+extern "C" {
+
+void HALSIM_ResetAnalogOutData(int32_t index) {}
+int32_t HALSIM_RegisterAnalogOutVoltageCallback(int32_t index,
+                                                HAL_NotifyCallback callback,
+                                                void* param,
+                                                HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelAnalogOutVoltageCallback(int32_t index, int32_t uid) {}
+double HALSIM_GetAnalogOutVoltage(int32_t index) { return 0; }
+void HALSIM_SetAnalogOutVoltage(int32_t index, double voltage) {}
+
+int32_t HALSIM_RegisterAnalogOutInitializedCallback(int32_t index,
+                                                    HAL_NotifyCallback callback,
+                                                    void* param,
+                                                    HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelAnalogOutInitializedCallback(int32_t index, int32_t uid) {}
+HAL_Bool HALSIM_GetAnalogOutInitialized(int32_t index) { return false; }
+void HALSIM_SetAnalogOutInitialized(int32_t index, HAL_Bool initialized) {}
+
+void HALSIM_RegisterAnalogOutAllCallbacks(int32_t index,
+                                          HAL_NotifyCallback callback,
+                                          void* param, HAL_Bool initialNotify) {
+}
+
+}  // extern "C"

--- a/hal/src/main/native/athena/MockDataShim/AnalogTriggerData.cpp
+++ b/hal/src/main/native/athena/MockDataShim/AnalogTriggerData.cpp
@@ -1,0 +1,63 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2017 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "MockData/AnalogTriggerData.h"
+
+extern "C" {
+
+void HALSIM_ResetAnalogTriggerData(int32_t index) {}
+int32_t HALSIM_RegisterAnalogTriggerInitializedCallback(
+    int32_t index, HAL_NotifyCallback callback, void* param,
+    HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelAnalogTriggerInitializedCallback(int32_t index, int32_t uid) {
+}
+HAL_Bool HALSIM_GetAnalogTriggerInitialized(int32_t index) { return false; }
+void HALSIM_SetAnalogTriggerInitialized(int32_t index, HAL_Bool initialized) {}
+
+int32_t HALSIM_RegisterAnalogTriggerTriggerLowerBoundCallback(
+    int32_t index, HAL_NotifyCallback callback, void* param,
+    HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelAnalogTriggerTriggerLowerBoundCallback(int32_t index,
+                                                         int32_t uid) {}
+double HALSIM_GetAnalogTriggerTriggerLowerBound(int32_t index) { return 0; }
+void HALSIM_SetAnalogTriggerTriggerLowerBound(int32_t index,
+                                              double triggerLowerBound) {}
+
+int32_t HALSIM_RegisterAnalogTriggerTriggerUpperBoundCallback(
+    int32_t index, HAL_NotifyCallback callback, void* param,
+    HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelAnalogTriggerTriggerUpperBoundCallback(int32_t index,
+                                                         int32_t uid) {}
+double HALSIM_GetAnalogTriggerTriggerUpperBound(int32_t index) { return 0; }
+void HALSIM_SetAnalogTriggerTriggerUpperBound(int32_t index,
+                                              double triggerUpperBound) {}
+
+int32_t HALSIM_RegisterAnalogTriggerTriggerModeCallback(
+    int32_t index, HAL_NotifyCallback callback, void* param,
+    HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelAnalogTriggerTriggerModeCallback(int32_t index, int32_t uid) {
+}
+HALSIM_AnalogTriggerMode HALSIM_GetAnalogTriggerTriggerMode(int32_t index) {
+  return HALSIM_AnalogTriggerMode::HALSIM_AnalogTriggerUnassigned;
+}
+void HALSIM_SetAnalogTriggerTriggerMode(int32_t index,
+                                        HALSIM_AnalogTriggerMode triggerMode) {}
+
+void HALSIM_RegisterAnalogTriggerAllCallbacks(int32_t index,
+                                              HAL_NotifyCallback callback,
+                                              void* param,
+                                              HAL_Bool initialNotify) {}
+
+}  // extern "C"

--- a/hal/src/main/native/athena/MockDataShim/CanData.cpp
+++ b/hal/src/main/native/athena/MockDataShim/CanData.cpp
@@ -1,0 +1,50 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2017 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "MockData/CanData.h"
+
+extern "C" {
+
+void HALSIM_ResetCanData() {}
+
+int32_t HALSIM_RegisterCanSendMessageCallback(
+    HAL_CAN_SendMessageCallback callback, void* param) {
+  return 0;
+}
+void HALSIM_CancelCanSendMessageCallback(int32_t uid) {}
+
+int32_t HALSIM_RegisterCanReceiveMessageCallback(
+    HAL_CAN_ReceiveMessageCallback callback, void* param) {
+  return 0;
+}
+void HALSIM_CancelCanReceiveMessageCallback(int32_t uid) {}
+
+int32_t HALSIM_RegisterCanOpenStreamCallback(
+    HAL_CAN_OpenStreamSessionCallback callback, void* param) {
+  return 0;
+}
+void HALSIM_CancelCanOpenStreamCallback(int32_t uid) {}
+
+int32_t HALSIM_RegisterCanCloseStreamCallback(
+    HAL_CAN_CloseStreamSessionCallback callback, void* param) {
+  return 0;
+}
+void HALSIM_CancelCanCloseStreamCallback(int32_t uid) {}
+
+int32_t HALSIM_RegisterCanReadStreamCallback(
+    HAL_CAN_ReadStreamSessionCallback callback, void* param) {
+  return 0;
+}
+void HALSIM_CancelCanReadStreamCallback(int32_t uid) {}
+
+int32_t HALSIM_RegisterCanGetCANStatusCallback(
+    HAL_CAN_GetCANStatusCallback callback, void* param) {
+  return 0;
+}
+void HALSIM_CancelCanGetCANStatusCallback(int32_t uid) {}
+
+}  // extern "C"

--- a/hal/src/main/native/athena/MockDataShim/DIOData.cpp
+++ b/hal/src/main/native/athena/MockDataShim/DIOData.cpp
@@ -1,0 +1,64 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2017 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "MockData/DIOData.h"
+
+extern "C" {
+
+void HALSIM_ResetDIOData(int32_t index) {}
+int32_t HALSIM_RegisterDIOInitializedCallback(int32_t index,
+                                              HAL_NotifyCallback callback,
+                                              void* param,
+                                              HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelDIOInitializedCallback(int32_t index, int32_t uid) {}
+HAL_Bool HALSIM_GetDIOInitialized(int32_t index) { return false; }
+void HALSIM_SetDIOInitialized(int32_t index, HAL_Bool initialized) {}
+
+int32_t HALSIM_RegisterDIOValueCallback(int32_t index,
+                                        HAL_NotifyCallback callback,
+                                        void* param, HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelDIOValueCallback(int32_t index, int32_t uid) {}
+HAL_Bool HALSIM_GetDIOValue(int32_t index) { return false; }
+void HALSIM_SetDIOValue(int32_t index, HAL_Bool value) {}
+
+int32_t HALSIM_RegisterDIOPulseLengthCallback(int32_t index,
+                                              HAL_NotifyCallback callback,
+                                              void* param,
+                                              HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelDIOPulseLengthCallback(int32_t index, int32_t uid) {}
+double HALSIM_GetDIOPulseLength(int32_t index) { return 0; }
+void HALSIM_SetDIOPulseLength(int32_t index, double pulseLength) {}
+
+int32_t HALSIM_RegisterDIOIsInputCallback(int32_t index,
+                                          HAL_NotifyCallback callback,
+                                          void* param, HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelDIOIsInputCallback(int32_t index, int32_t uid) {}
+HAL_Bool HALSIM_GetDIOIsInput(int32_t index) { return false; }
+void HALSIM_SetDIOIsInput(int32_t index, HAL_Bool isInput) {}
+
+int32_t HALSIM_RegisterDIOFilterIndexCallback(int32_t index,
+                                              HAL_NotifyCallback callback,
+                                              void* param,
+                                              HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelDIOFilterIndexCallback(int32_t index, int32_t uid) {}
+int32_t HALSIM_GetDIOFilterIndex(int32_t index) { return 0; }
+void HALSIM_SetDIOFilterIndex(int32_t index, int32_t filterIndex) {}
+
+void HALSIM_RegisterDIOAllCallbacks(int32_t index, HAL_NotifyCallback callback,
+                                    void* param, HAL_Bool initialNotify) {}
+
+}  // extern "C"

--- a/hal/src/main/native/athena/MockDataShim/DigitalPWMData.cpp
+++ b/hal/src/main/native/athena/MockDataShim/DigitalPWMData.cpp
@@ -1,0 +1,47 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2017 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "MockData/DigitalPWMData.h"
+
+extern "C" {
+
+void HALSIM_ResetDigitalPWMData(int32_t index) {}
+int32_t HALSIM_RegisterDigitalPWMInitializedCallback(
+    int32_t index, HAL_NotifyCallback callback, void* param,
+    HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelDigitalPWMInitializedCallback(int32_t index, int32_t uid) {}
+HAL_Bool HALSIM_GetDigitalPWMInitialized(int32_t index) { return false; }
+void HALSIM_SetDigitalPWMInitialized(int32_t index, HAL_Bool initialized) {}
+
+int32_t HALSIM_RegisterDigitalPWMDutyCycleCallback(int32_t index,
+                                                   HAL_NotifyCallback callback,
+                                                   void* param,
+                                                   HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelDigitalPWMDutyCycleCallback(int32_t index, int32_t uid) {}
+double HALSIM_GetDigitalPWMDutyCycle(int32_t index) { return 0; }
+void HALSIM_SetDigitalPWMDutyCycle(int32_t index, double dutyCycle) {}
+
+int32_t HALSIM_RegisterDigitalPWMPinCallback(int32_t index,
+                                             HAL_NotifyCallback callback,
+                                             void* param,
+                                             HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelDigitalPWMPinCallback(int32_t index, int32_t uid) {}
+int32_t HALSIM_GetDigitalPWMPin(int32_t index) { return 0; }
+void HALSIM_SetDigitalPWMPin(int32_t index, int32_t pin) {}
+
+void HALSIM_RegisterDigitalPWMAllCallbacks(int32_t index,
+                                           HAL_NotifyCallback callback,
+                                           void* param,
+                                           HAL_Bool initialNotify) {}
+
+}  // extern "C"

--- a/hal/src/main/native/athena/MockDataShim/DriverStationData.cpp
+++ b/hal/src/main/native/athena/MockDataShim/DriverStationData.cpp
@@ -1,0 +1,103 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2017 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "MockData/DriverStationData.h"
+
+extern "C" {
+
+void HALSIM_ResetDriverStationData(void) {}
+int32_t HALSIM_RegisterDriverStationEnabledCallback(HAL_NotifyCallback callback,
+                                                    void* param,
+                                                    HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelDriverStationEnabledCallback(int32_t uid) {}
+HAL_Bool HALSIM_GetDriverStationEnabled() { return false; }
+void HALSIM_SetDriverStationEnabled(HAL_Bool enabled) {}
+
+int32_t HALSIM_RegisterDriverStationAutonomousCallback(
+    HAL_NotifyCallback callback, void* param, HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelDriverStationAutonomousCallback(int32_t uid) {}
+HAL_Bool HALSIM_GetDriverStationAutonomous() { return false; }
+void HALSIM_SetDriverStationAutonomous(HAL_Bool autonomous) {}
+
+int32_t HALSIM_RegisterDriverStationTestCallback(HAL_NotifyCallback callback,
+                                                 void* param,
+                                                 HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelDriverStationTestCallback(int32_t uid) {}
+HAL_Bool HALSIM_GetDriverStationTest() { return false; }
+void HALSIM_SetDriverStationTest(HAL_Bool test) {}
+
+int32_t HALSIM_RegisterDriverStationEStopCallback(HAL_NotifyCallback callback,
+                                                  void* param,
+                                                  HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelDriverStationEStopCallback(int32_t uid) {}
+HAL_Bool HALSIM_GetDriverStationEStop() { return false; }
+void HALSIM_SetDriverStationEStop(HAL_Bool eStop) {}
+
+int32_t HALSIM_RegisterDriverStationFmsAttachedCallback(
+    HAL_NotifyCallback callback, void* param, HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelDriverStationFmsAttachedCallback(int32_t uid) {}
+HAL_Bool HALSIM_GetDriverStationFmsAttached() { return false; }
+void HALSIM_SetDriverStationFmsAttached(HAL_Bool fmsAttached) {}
+
+int32_t HALSIM_RegisterDriverStationDsAttachedCallback(
+    HAL_NotifyCallback callback, void* param, HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelDriverStationDsAttachedCallback(int32_t uid) {}
+HAL_Bool HALSIM_GetDriverStationDsAttached() { return false; }
+void HALSIM_SetDriverStationDsAttached(HAL_Bool dsAttached) {}
+
+int32_t HALSIM_RegisterDriverStationAllianceStationIdCallback(
+    HAL_NotifyCallback callback, void* param, HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelDriverStationAllianceStationIdCallback(int32_t uid) {}
+HAL_AllianceStationID HALSIM_GetDriverStationAllianceStationId() {
+  return HAL_AllianceStationID::HAL_AllianceStationID_kRed1;
+}
+void HALSIM_SetDriverStationAllianceStationId(
+    HAL_AllianceStationID allianceStationId) {}
+
+int32_t HALSIM_RegisterDriverStationMatchTimeCallback(
+    HAL_NotifyCallback callback, void* param, HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelDriverStationMatchTimeCallback(int32_t uid) {}
+double HALSIM_GetDriverStationMatchTime() { return 0; }
+void HALSIM_SetDriverStationMatchTime(double matchTime) {}
+
+void HALSIM_SetJoystickAxes(int32_t joystickNum, const HAL_JoystickAxes* axes) {
+}
+void HALSIM_SetJoystickPOVs(int32_t joystickNum, const HAL_JoystickPOVs* povs) {
+}
+void HALSIM_SetJoystickButtons(int32_t joystickNum,
+                               const HAL_JoystickButtons* buttons) {}
+void HALSIM_SetJoystickDescriptor(int32_t joystickNum,
+                                  const HAL_JoystickDescriptor* descriptor) {}
+
+void HALSIM_GetJoystickOutputs(int32_t joystickNum, int64_t* outputs,
+                               int32_t* leftRumble, int32_t* rightRumble) {}
+
+void HALSIM_SetMatchInfo(const HAL_MatchInfo* info) {}
+
+void HALSIM_RegisterDriverStationAllCallbacks(HAL_NotifyCallback callback,
+                                              void* param,
+                                              HAL_Bool initialNotify) {}
+
+void HALSIM_NotifyDriverStationNewData(void) {}
+
+}  // extern "C"

--- a/hal/src/main/native/athena/MockDataShim/EncoderData.cpp
+++ b/hal/src/main/native/athena/MockDataShim/EncoderData.cpp
@@ -1,0 +1,97 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2017 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "MockData/EncoderData.h"
+
+extern "C" {
+
+void HALSIM_ResetEncoderData(int32_t index) {}
+int32_t HALSIM_RegisterEncoderInitializedCallback(int32_t index,
+                                                  HAL_NotifyCallback callback,
+                                                  void* param,
+                                                  HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelEncoderInitializedCallback(int32_t index, int32_t uid) {}
+HAL_Bool HALSIM_GetEncoderInitialized(int32_t index) { return false; }
+void HALSIM_SetEncoderInitialized(int32_t index, HAL_Bool initialized) {}
+
+int32_t HALSIM_RegisterEncoderCountCallback(int32_t index,
+                                            HAL_NotifyCallback callback,
+                                            void* param,
+                                            HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelEncoderCountCallback(int32_t index, int32_t uid) {}
+int32_t HALSIM_GetEncoderCount(int32_t index) { return 0; }
+void HALSIM_SetEncoderCount(int32_t index, int32_t count) {}
+
+int32_t HALSIM_RegisterEncoderPeriodCallback(int32_t index,
+                                             HAL_NotifyCallback callback,
+                                             void* param,
+                                             HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelEncoderPeriodCallback(int32_t index, int32_t uid) {}
+double HALSIM_GetEncoderPeriod(int32_t index) { return 0; }
+void HALSIM_SetEncoderPeriod(int32_t index, double period) {}
+
+int32_t HALSIM_RegisterEncoderResetCallback(int32_t index,
+                                            HAL_NotifyCallback callback,
+                                            void* param,
+                                            HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelEncoderResetCallback(int32_t index, int32_t uid) {}
+HAL_Bool HALSIM_GetEncoderReset(int32_t index) { return false; }
+void HALSIM_SetEncoderReset(int32_t index, HAL_Bool reset) {}
+
+int32_t HALSIM_RegisterEncoderMaxPeriodCallback(int32_t index,
+                                                HAL_NotifyCallback callback,
+                                                void* param,
+                                                HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelEncoderMaxPeriodCallback(int32_t index, int32_t uid) {}
+double HALSIM_GetEncoderMaxPeriod(int32_t index) { return 0; }
+void HALSIM_SetEncoderMaxPeriod(int32_t index, double maxPeriod) {}
+
+int32_t HALSIM_RegisterEncoderDirectionCallback(int32_t index,
+                                                HAL_NotifyCallback callback,
+                                                void* param,
+                                                HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelEncoderDirectionCallback(int32_t index, int32_t uid) {}
+HAL_Bool HALSIM_GetEncoderDirection(int32_t index) { return false; }
+void HALSIM_SetEncoderDirection(int32_t index, HAL_Bool direction) {}
+
+int32_t HALSIM_RegisterEncoderReverseDirectionCallback(
+    int32_t index, HAL_NotifyCallback callback, void* param,
+    HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelEncoderReverseDirectionCallback(int32_t index, int32_t uid) {}
+HAL_Bool HALSIM_GetEncoderReverseDirection(int32_t index) { return false; }
+void HALSIM_SetEncoderReverseDirection(int32_t index,
+                                       HAL_Bool reverseDirection) {}
+
+int32_t HALSIM_RegisterEncoderSamplesToAverageCallback(
+    int32_t index, HAL_NotifyCallback callback, void* param,
+    HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelEncoderSamplesToAverageCallback(int32_t index, int32_t uid) {}
+int32_t HALSIM_GetEncoderSamplesToAverage(int32_t index) { return 0; }
+void HALSIM_SetEncoderSamplesToAverage(int32_t index,
+                                       int32_t samplesToAverage) {}
+
+void HALSIM_RegisterEncoderAllCallbacks(int32_t index,
+                                        HAL_NotifyCallback callback,
+                                        void* param, HAL_Bool initialNotify) {}
+
+}  // extern "C"

--- a/hal/src/main/native/athena/MockDataShim/I2CData.cpp
+++ b/hal/src/main/native/athena/MockDataShim/I2CData.cpp
@@ -1,0 +1,38 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2017 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "MockData/I2CData.h"
+
+extern "C" {
+
+void HALSIM_ResetI2CData(int32_t index) {}
+
+int32_t HALSIM_RegisterI2CInitializedCallback(int32_t index,
+                                              HAL_NotifyCallback callback,
+                                              void* param,
+                                              HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelI2CInitializedCallback(int32_t index, int32_t uid) {}
+HAL_Bool HALSIM_GetI2CInitialized(int32_t index) { return false; }
+void HALSIM_SetI2CInitialized(int32_t index, HAL_Bool initialized) {}
+
+int32_t HALSIM_RegisterI2CReadCallback(int32_t index,
+                                       HAL_BufferCallback callback,
+                                       void* param) {
+  return 0;
+}
+void HALSIM_CancelI2CReadCallback(int32_t index, int32_t uid) {}
+
+int32_t HALSIM_RegisterI2CWriteCallback(int32_t index,
+                                        HAL_ConstBufferCallback callback,
+                                        void* param) {
+  return 0;
+}
+void HALSIM_CancelI2CWriteCallback(int32_t index, int32_t uid) {}
+
+}  // extern "C"

--- a/hal/src/main/native/athena/MockDataShim/MockHooks.cpp
+++ b/hal/src/main/native/athena/MockDataShim/MockHooks.cpp
@@ -1,0 +1,12 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2017 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+extern "C" {
+void HALSIM_WaitForProgramStart(void) {}
+void HALSIM_SetProgramStarted(void) {}
+void HALSIM_RestartTiming(void) {}
+}  // extern "C"

--- a/hal/src/main/native/athena/MockDataShim/PCMData.cpp
+++ b/hal/src/main/native/athena/MockDataShim/PCMData.cpp
@@ -1,0 +1,102 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2017 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "MockData/PCMData.h"
+
+extern "C" {
+
+void HALSIM_ResetPCMData(int32_t index) {}
+int32_t HALSIM_RegisterPCMSolenoidInitializedCallback(
+    int32_t index, int32_t channel, HAL_NotifyCallback callback, void* param,
+    HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelPCMSolenoidInitializedCallback(int32_t index, int32_t channel,
+                                                 int32_t uid) {}
+HAL_Bool HALSIM_GetPCMSolenoidInitialized(int32_t index, int32_t channel) {
+  return false;
+}
+void HALSIM_SetPCMSolenoidInitialized(int32_t index, int32_t channel,
+                                      HAL_Bool solenoidInitialized) {}
+
+int32_t HALSIM_RegisterPCMSolenoidOutputCallback(int32_t index, int32_t channel,
+                                                 HAL_NotifyCallback callback,
+                                                 void* param,
+                                                 HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelPCMSolenoidOutputCallback(int32_t index, int32_t channel,
+                                            int32_t uid) {}
+HAL_Bool HALSIM_GetPCMSolenoidOutput(int32_t index, int32_t channel) {
+  return false;
+}
+void HALSIM_SetPCMSolenoidOutput(int32_t index, int32_t channel,
+                                 HAL_Bool solenoidOutput) {}
+
+int32_t HALSIM_RegisterPCMCompressorInitializedCallback(
+    int32_t index, HAL_NotifyCallback callback, void* param,
+    HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelPCMCompressorInitializedCallback(int32_t index, int32_t uid) {
+}
+HAL_Bool HALSIM_GetPCMCompressorInitialized(int32_t index) { return false; }
+void HALSIM_SetPCMCompressorInitialized(int32_t index,
+                                        HAL_Bool compressorInitialized) {}
+
+int32_t HALSIM_RegisterPCMCompressorOnCallback(int32_t index,
+                                               HAL_NotifyCallback callback,
+                                               void* param,
+                                               HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelPCMCompressorOnCallback(int32_t index, int32_t uid) {}
+HAL_Bool HALSIM_GetPCMCompressorOn(int32_t index) { return false; }
+void HALSIM_SetPCMCompressorOn(int32_t index, HAL_Bool compressorOn) {}
+
+int32_t HALSIM_RegisterPCMClosedLoopEnabledCallback(int32_t index,
+                                                    HAL_NotifyCallback callback,
+                                                    void* param,
+                                                    HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelPCMClosedLoopEnabledCallback(int32_t index, int32_t uid) {}
+HAL_Bool HALSIM_GetPCMClosedLoopEnabled(int32_t index) { return false; }
+void HALSIM_SetPCMClosedLoopEnabled(int32_t index, HAL_Bool closedLoopEnabled) {
+}
+
+int32_t HALSIM_RegisterPCMPressureSwitchCallback(int32_t index,
+                                                 HAL_NotifyCallback callback,
+                                                 void* param,
+                                                 HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelPCMPressureSwitchCallback(int32_t index, int32_t uid) {}
+HAL_Bool HALSIM_GetPCMPressureSwitch(int32_t index) { return false; }
+void HALSIM_SetPCMPressureSwitch(int32_t index, HAL_Bool pressureSwitch) {}
+
+int32_t HALSIM_RegisterPCMCompressorCurrentCallback(int32_t index,
+                                                    HAL_NotifyCallback callback,
+                                                    void* param,
+                                                    HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelPCMCompressorCurrentCallback(int32_t index, int32_t uid) {}
+double HALSIM_GetPCMCompressorCurrent(int32_t index) { return 0; }
+void HALSIM_SetPCMCompressorCurrent(int32_t index, double compressorCurrent) {}
+
+void HALSIM_RegisterPCMAllNonSolenoidCallbacks(int32_t index,
+                                               HAL_NotifyCallback callback,
+                                               void* param,
+                                               HAL_Bool initialNotify) {}
+
+void HALSIM_RegisterPCMAllSolenoidCallbacks(int32_t index, int32_t channel,
+                                            HAL_NotifyCallback callback,
+                                            void* param,
+                                            HAL_Bool initialNotify) {}
+
+}  // extern "C"

--- a/hal/src/main/native/athena/MockDataShim/PDPData.cpp
+++ b/hal/src/main/native/athena/MockDataShim/PDPData.cpp
@@ -1,0 +1,57 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2017 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "MockData/PDPData.h"
+
+extern "C" {
+
+void HALSIM_ResetPDPData(int32_t index) {}
+int32_t HALSIM_RegisterPDPInitializedCallback(int32_t index,
+                                              HAL_NotifyCallback callback,
+                                              void* param,
+                                              HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelPDPInitializedCallback(int32_t index, int32_t uid) {}
+HAL_Bool HALSIM_GetPDPInitialized(int32_t index) { return false; }
+void HALSIM_SetPDPInitialized(int32_t index, HAL_Bool initialized) {}
+
+int32_t HALSIM_RegisterPDPTemperatureCallback(int32_t index,
+                                              HAL_NotifyCallback callback,
+                                              void* param,
+                                              HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelPDPTemperatureCallback(int32_t index, int32_t uid) {}
+double HALSIM_GetPDPTemperature(int32_t index) { return 0; }
+void HALSIM_SetPDPTemperature(int32_t index, double temperature) {}
+
+int32_t HALSIM_RegisterPDPVoltageCallback(int32_t index,
+                                          HAL_NotifyCallback callback,
+                                          void* param, HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelPDPVoltageCallback(int32_t index, int32_t uid) {}
+double HALSIM_GetPDPVoltage(int32_t index) { return 0; }
+void HALSIM_SetPDPVoltage(int32_t index, double voltage) {}
+
+int32_t HALSIM_RegisterPDPCurrentCallback(int32_t index, int32_t channel,
+                                          HAL_NotifyCallback callback,
+                                          void* param, HAL_Bool initialNotify) {
+  return false;
+}
+void HALSIM_CancelPDPCurrentCallback(int32_t index, int32_t channel,
+                                     int32_t uid) {}
+double HALSIM_GetPDPCurrent(int32_t index, int32_t channel) { return 0; }
+void HALSIM_SetPDPCurrent(int32_t index, int32_t channel, double current) {}
+
+void HALSIM_RegisterPDPAllNonCurrentCallbacks(int32_t index, int32_t channel,
+                                              HAL_NotifyCallback callback,
+                                              void* param,
+                                              HAL_Bool initialNotify) {}
+
+}  // extern "C"

--- a/hal/src/main/native/athena/MockDataShim/PWMData.cpp
+++ b/hal/src/main/native/athena/MockDataShim/PWMData.cpp
@@ -1,0 +1,75 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2017 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "MockData/PWMData.h"
+
+extern "C" {
+
+void HALSIM_ResetPWMData(int32_t index) {}
+int32_t HALSIM_RegisterPWMInitializedCallback(int32_t index,
+                                              HAL_NotifyCallback callback,
+                                              void* param,
+                                              HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelPWMInitializedCallback(int32_t index, int32_t uid) {}
+HAL_Bool HALSIM_GetPWMInitialized(int32_t index) { return false; }
+void HALSIM_SetPWMInitialized(int32_t index, HAL_Bool initialized) {}
+
+int32_t HALSIM_RegisterPWMRawValueCallback(int32_t index,
+                                           HAL_NotifyCallback callback,
+                                           void* param,
+                                           HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelPWMRawValueCallback(int32_t index, int32_t uid) {}
+int32_t HALSIM_GetPWMRawValue(int32_t index) { return 0; }
+void HALSIM_SetPWMRawValue(int32_t index, int32_t rawValue) {}
+
+int32_t HALSIM_RegisterPWMSpeedCallback(int32_t index,
+                                        HAL_NotifyCallback callback,
+                                        void* param, HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelPWMSpeedCallback(int32_t index, int32_t uid) {}
+double HALSIM_GetPWMSpeed(int32_t index) { return 0; }
+void HALSIM_SetPWMSpeed(int32_t index, double speed) {}
+
+int32_t HALSIM_RegisterPWMPositionCallback(int32_t index,
+                                           HAL_NotifyCallback callback,
+                                           void* param,
+                                           HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelPWMPositionCallback(int32_t index, int32_t uid) {}
+double HALSIM_GetPWMPosition(int32_t index) { return 0; }
+void HALSIM_SetPWMPosition(int32_t index, double position) {}
+
+int32_t HALSIM_RegisterPWMPeriodScaleCallback(int32_t index,
+                                              HAL_NotifyCallback callback,
+                                              void* param,
+                                              HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelPWMPeriodScaleCallback(int32_t index, int32_t uid) {}
+int32_t HALSIM_GetPWMPeriodScale(int32_t index) { return 0; }
+void HALSIM_SetPWMPeriodScale(int32_t index, int32_t periodScale) {}
+
+int32_t HALSIM_RegisterPWMZeroLatchCallback(int32_t index,
+                                            HAL_NotifyCallback callback,
+                                            void* param,
+                                            HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelPWMZeroLatchCallback(int32_t index, int32_t uid) {}
+HAL_Bool HALSIM_GetPWMZeroLatch(int32_t index) { return false; }
+void HALSIM_SetPWMZeroLatch(int32_t index, HAL_Bool zeroLatch) {}
+
+void HALSIM_RegisterPWMAllCallbacks(int32_t index, HAL_NotifyCallback callback,
+                                    void* param, HAL_Bool initialNotify) {}
+
+}  // extern "C"

--- a/hal/src/main/native/athena/MockDataShim/RelayData.cpp
+++ b/hal/src/main/native/athena/MockDataShim/RelayData.cpp
@@ -1,0 +1,57 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2017 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "MockData/RelayData.h"
+
+extern "C" {
+
+void HALSIM_ResetRelayData(int32_t index) {}
+int32_t HALSIM_RegisterRelayInitializedForwardCallback(
+    int32_t index, HAL_NotifyCallback callback, void* param,
+    HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelRelayInitializedForwardCallback(int32_t index, int32_t uid) {}
+HAL_Bool HALSIM_GetRelayInitializedForward(int32_t index) { return false; }
+void HALSIM_SetRelayInitializedForward(int32_t index,
+                                       HAL_Bool initializedForward) {}
+
+int32_t HALSIM_RegisterRelayInitializedReverseCallback(
+    int32_t index, HAL_NotifyCallback callback, void* param,
+    HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelRelayInitializedReverseCallback(int32_t index, int32_t uid) {}
+HAL_Bool HALSIM_GetRelayInitializedReverse(int32_t index) { return false; }
+void HALSIM_SetRelayInitializedReverse(int32_t index,
+                                       HAL_Bool initializedReverse) {}
+
+int32_t HALSIM_RegisterRelayForwardCallback(int32_t index,
+                                            HAL_NotifyCallback callback,
+                                            void* param,
+                                            HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelRelayForwardCallback(int32_t index, int32_t uid) {}
+HAL_Bool HALSIM_GetRelayForward(int32_t index) { return false; }
+void HALSIM_SetRelayForward(int32_t index, HAL_Bool forward) {}
+
+int32_t HALSIM_RegisterRelayReverseCallback(int32_t index,
+                                            HAL_NotifyCallback callback,
+                                            void* param,
+                                            HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelRelayReverseCallback(int32_t index, int32_t uid) {}
+HAL_Bool HALSIM_GetRelayReverse(int32_t index) { return false; }
+void HALSIM_SetRelayReverse(int32_t index, HAL_Bool reverse) {}
+
+void HALSIM_RegisterRelayAllCallcbaks(int32_t index,
+                                      HAL_NotifyCallback callback, void* param,
+                                      HAL_Bool initialNotify) {}
+
+}  // extern "C"

--- a/hal/src/main/native/athena/MockDataShim/RoboRioData.cpp
+++ b/hal/src/main/native/athena/MockDataShim/RoboRioData.cpp
@@ -1,0 +1,165 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2017 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "MockData/RoboRioData.h"
+
+extern "C" {
+
+void HALSIM_ResetRoboRioData(int32_t index) {}
+int32_t HALSIM_RegisterRoboRioFPGAButtonCallback(int32_t index,
+                                                 HAL_NotifyCallback callback,
+                                                 void* param,
+                                                 HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelRoboRioFPGAButtonCallback(int32_t index, int32_t uid) {}
+HAL_Bool HALSIM_GetRoboRioFPGAButton(int32_t index) { return false; }
+void HALSIM_SetRoboRioFPGAButton(int32_t index, HAL_Bool fPGAButton) {}
+
+int32_t HALSIM_RegisterRoboRioVInVoltageCallback(int32_t index,
+                                                 HAL_NotifyCallback callback,
+                                                 void* param,
+                                                 HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelRoboRioVInVoltageCallback(int32_t index, int32_t uid) {}
+double HALSIM_GetRoboRioVInVoltage(int32_t index) { return 0; }
+void HALSIM_SetRoboRioVInVoltage(int32_t index, double vInVoltage) {}
+
+int32_t HALSIM_RegisterRoboRioVInCurrentCallback(int32_t index,
+                                                 HAL_NotifyCallback callback,
+                                                 void* param,
+                                                 HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelRoboRioVInCurrentCallback(int32_t index, int32_t uid) {}
+double HALSIM_GetRoboRioVInCurrent(int32_t index) { return 0; }
+void HALSIM_SetRoboRioVInCurrent(int32_t index, double vInCurrent) {}
+
+int32_t HALSIM_RegisterRoboRioUserVoltage6VCallback(int32_t index,
+                                                    HAL_NotifyCallback callback,
+                                                    void* param,
+                                                    HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelRoboRioUserVoltage6VCallback(int32_t index, int32_t uid) {}
+double HALSIM_GetRoboRioUserVoltage6V(int32_t index) { return 0; }
+void HALSIM_SetRoboRioUserVoltage6V(int32_t index, double userVoltage6V) {}
+
+int32_t HALSIM_RegisterRoboRioUserCurrent6VCallback(int32_t index,
+                                                    HAL_NotifyCallback callback,
+                                                    void* param,
+                                                    HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelRoboRioUserCurrent6VCallback(int32_t index, int32_t uid) {}
+double HALSIM_GetRoboRioUserCurrent6V(int32_t index) { return 0; }
+void HALSIM_SetRoboRioUserCurrent6V(int32_t index, double userCurrent6V) {}
+
+int32_t HALSIM_RegisterRoboRioUserActive6VCallback(int32_t index,
+                                                   HAL_NotifyCallback callback,
+                                                   void* param,
+                                                   HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelRoboRioUserActive6VCallback(int32_t index, int32_t uid) {}
+HAL_Bool HALSIM_GetRoboRioUserActive6V(int32_t index) { return false; }
+void HALSIM_SetRoboRioUserActive6V(int32_t index, HAL_Bool userActive6V) {}
+
+int32_t HALSIM_RegisterRoboRioUserVoltage5VCallback(int32_t index,
+                                                    HAL_NotifyCallback callback,
+                                                    void* param,
+                                                    HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelRoboRioUserVoltage5VCallback(int32_t index, int32_t uid) {}
+double HALSIM_GetRoboRioUserVoltage5V(int32_t index) { return 0; }
+void HALSIM_SetRoboRioUserVoltage5V(int32_t index, double userVoltage5V) {}
+
+int32_t HALSIM_RegisterRoboRioUserCurrent5VCallback(int32_t index,
+                                                    HAL_NotifyCallback callback,
+                                                    void* param,
+                                                    HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelRoboRioUserCurrent5VCallback(int32_t index, int32_t uid) {}
+double HALSIM_GetRoboRioUserCurrent5V(int32_t index) { return 0; }
+void HALSIM_SetRoboRioUserCurrent5V(int32_t index, double userCurrent5V) {}
+
+int32_t HALSIM_RegisterRoboRioUserActive5VCallback(int32_t index,
+                                                   HAL_NotifyCallback callback,
+                                                   void* param,
+                                                   HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelRoboRioUserActive5VCallback(int32_t index, int32_t uid) {}
+HAL_Bool HALSIM_GetRoboRioUserActive5V(int32_t index) { return false; }
+void HALSIM_SetRoboRioUserActive5V(int32_t index, HAL_Bool userActive5V) {}
+
+int32_t HALSIM_RegisterRoboRioUserVoltage3V3Callback(
+    int32_t index, HAL_NotifyCallback callback, void* param,
+    HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelRoboRioUserVoltage3V3Callback(int32_t index, int32_t uid) {}
+double HALSIM_GetRoboRioUserVoltage3V3(int32_t index) { return 0; }
+void HALSIM_SetRoboRioUserVoltage3V3(int32_t index, double userVoltage3V3) {}
+
+int32_t HALSIM_RegisterRoboRioUserCurrent3V3Callback(
+    int32_t index, HAL_NotifyCallback callback, void* param,
+    HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelRoboRioUserCurrent3V3Callback(int32_t index, int32_t uid) {}
+double HALSIM_GetRoboRioUserCurrent3V3(int32_t index) { return 0; }
+void HALSIM_SetRoboRioUserCurrent3V3(int32_t index, double userCurrent3V3) {}
+
+int32_t HALSIM_RegisterRoboRioUserActive3V3Callback(int32_t index,
+                                                    HAL_NotifyCallback callback,
+                                                    void* param,
+                                                    HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelRoboRioUserActive3V3Callback(int32_t index, int32_t uid) {}
+HAL_Bool HALSIM_GetRoboRioUserActive3V3(int32_t index) { return false; }
+void HALSIM_SetRoboRioUserActive3V3(int32_t index, HAL_Bool userActive3V3) {}
+
+int32_t HALSIM_RegisterRoboRioUserFaults6VCallback(int32_t index,
+                                                   HAL_NotifyCallback callback,
+                                                   void* param,
+                                                   HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelRoboRioUserFaults6VCallback(int32_t index, int32_t uid) {}
+int32_t HALSIM_GetRoboRioUserFaults6V(int32_t index) { return 0; }
+void HALSIM_SetRoboRioUserFaults6V(int32_t index, int32_t userFaults6V) {}
+
+int32_t HALSIM_RegisterRoboRioUserFaults5VCallback(int32_t index,
+                                                   HAL_NotifyCallback callback,
+                                                   void* param,
+                                                   HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelRoboRioUserFaults5VCallback(int32_t index, int32_t uid) {}
+int32_t HALSIM_GetRoboRioUserFaults5V(int32_t index) { return 0; }
+void HALSIM_SetRoboRioUserFaults5V(int32_t index, int32_t userFaults5V) {}
+
+int32_t HALSIM_RegisterRoboRioUserFaults3V3Callback(int32_t index,
+                                                    HAL_NotifyCallback callback,
+                                                    void* param,
+                                                    HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelRoboRioUserFaults3V3Callback(int32_t index, int32_t uid) {}
+int32_t HALSIM_GetRoboRioUserFaults3V3(int32_t index) { return 0; }
+void HALSIM_SetRoboRioUserFaults3V3(int32_t index, int32_t userFaults3V3) {}
+
+void HALSIM_RegisterRoboRioAllCallbacks(int32_t index,
+                                        HAL_NotifyCallback callback,
+                                        void* param, HAL_Bool initialNotify) {}
+
+}  // extern "C"

--- a/hal/src/main/native/athena/MockDataShim/SPIAccelerometerData.cpp
+++ b/hal/src/main/native/athena/MockDataShim/SPIAccelerometerData.cpp
@@ -1,0 +1,66 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2017 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "MockData/SPIAccelerometerData.h"
+
+extern "C" {
+
+void HALSIM_ResetSPIAccelerometerData(int32_t index) {}
+int32_t HALSIM_RegisterSPIAccelerometerActiveCallback(
+    int32_t index, HAL_NotifyCallback callback, void* param,
+    HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelSPIAccelerometerActiveCallback(int32_t index, int32_t uid) {}
+HAL_Bool HALSIM_GetSPIAccelerometerActive(int32_t index) { return false; }
+void HALSIM_SetSPIAccelerometerActive(int32_t index, HAL_Bool active) {}
+
+int32_t HALSIM_RegisterSPIAccelerometerRangeCallback(
+    int32_t index, HAL_NotifyCallback callback, void* param,
+    HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelSPIAccelerometerRangeCallback(int32_t index, int32_t uid) {}
+int32_t HALSIM_GetSPIAccelerometerRange(int32_t index) { return 0; }
+void HALSIM_SetSPIAccelerometerRange(int32_t index, int32_t range) {}
+
+int32_t HALSIM_RegisterSPIAccelerometerXCallback(int32_t index,
+                                                 HAL_NotifyCallback callback,
+                                                 void* param,
+                                                 HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelSPIAccelerometerXCallback(int32_t index, int32_t uid) {}
+double HALSIM_GetSPIAccelerometerX(int32_t index) { return 0; }
+void HALSIM_SetSPIAccelerometerX(int32_t index, double x) {}
+
+int32_t HALSIM_RegisterSPIAccelerometerYCallback(int32_t index,
+                                                 HAL_NotifyCallback callback,
+                                                 void* param,
+                                                 HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelSPIAccelerometerYCallback(int32_t index, int32_t uid) {}
+double HALSIM_GetSPIAccelerometerY(int32_t index) { return 0; }
+void HALSIM_SetSPIAccelerometerY(int32_t index, double y) {}
+
+int32_t HALSIM_RegisterSPIAccelerometerZCallback(int32_t index,
+                                                 HAL_NotifyCallback callback,
+                                                 void* param,
+                                                 HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelSPIAccelerometerZCallback(int32_t index, int32_t uid) {}
+double HALSIM_GetSPIAccelerometerZ(int32_t index) { return 0; }
+void HALSIM_SetSPIAccelerometerZ(int32_t index, double z) {}
+
+void HALSIM_RegisterSPIAccelerometerAllCallbcaks(int32_t index,
+                                                 HAL_NotifyCallback callback,
+                                                 void* param,
+                                                 HAL_Bool initialNotify) {}
+
+}  // extern "C"

--- a/hal/src/main/native/athena/MockDataShim/SPIData.cpp
+++ b/hal/src/main/native/athena/MockDataShim/SPIData.cpp
@@ -1,0 +1,55 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2017 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "MockData/SPIData.h"
+
+extern "C" {
+
+void HALSIM_ResetSPIData(int32_t index) {}
+
+int32_t HALSIM_RegisterSPIInitializedCallback(int32_t index,
+                                              HAL_NotifyCallback callback,
+                                              void* param,
+                                              HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelSPIInitializedCallback(int32_t index, int32_t uid) {}
+HAL_Bool HALSIM_GetSPIInitialized(int32_t index) { return false; }
+void HALSIM_SetSPIInitialized(int32_t index, HAL_Bool initialized) {}
+
+int32_t HALSIM_RegisterSPIReadCallback(int32_t index,
+                                       HAL_BufferCallback callback,
+                                       void* param) {
+  return 0;
+}
+void HALSIM_CancelSPIReadCallback(int32_t index, int32_t uid) {}
+
+int32_t HALSIM_RegisterSPIWriteCallback(int32_t index,
+                                        HAL_ConstBufferCallback callback,
+                                        void* param) {
+  return 0;
+}
+void HALSIM_CancelSPIWriteCallback(int32_t index, int32_t uid) {}
+
+int32_t HALSIM_RegisterSPIResetAccumulatorCallback(int32_t index,
+                                                   HAL_NotifyCallback callback,
+                                                   void* param,
+                                                   HAL_Bool initialNotify) {
+  return 0;
+}
+void HALSIM_CancelSPIResetAccumulatorCallback(int32_t index, int32_t uid) {}
+
+int32_t HALSIM_RegisterSPISetAccumulatorCallback(int32_t index,
+                                                 HAL_BufferCallback callback,
+                                                 void* param) {
+  return 0;
+}
+void HALSIM_CancelSPISetAccumulatorCallback(int32_t index, int32_t uid) {}
+void HALSIM_SetSPISetAccumulatorValue(int32_t index, int64_t value) {}
+int64_t HALSIM_GetSPIGetAccumulatorValue(int32_t index) { return 0; }
+
+}  // extern "C"


### PR DESCRIPTION
Makes it possible to check at runtime if the sim exists or not, which
was part of the reason for HAL_GetRuntimeType() api.